### PR TITLE
feat: add 1-space-per-stack support with self-admin and login labels

### DIFF
--- a/docs/migration-admin-to-roles.md
+++ b/docs/migration-admin-to-roles.md
@@ -197,9 +197,9 @@ vars:
 
 The `write_login_access_github_teams` and `admin_login_access_github_teams` values are inherited from the admin stack's existing `_spacelift-space.yaml` vars — no per-stack YAML changes required.
 
-### Login policy update
+### Login policy
 
-The `template-rego-policies/login.github.rego` template now includes label-based `space_write` / `space_admin` rules that match `write_access_github_team:<team>` and `admin_access_github_team:<team>` labels on dedicated spaces. The existing single login policy covers all dedicated spaces with no extra policies needed.
+No changes to `login.github.rego` are needed. Spacelift's space hierarchy cascades access: a user with `space_admin` on the admin stack's managed space automatically has admin on all child dedicated spaces. The `write_access_github_team:<t>` / `admin_access_github_team:<t>` labels on dedicated spaces are metadata only (useful for auditing/future Rego), not consumed by the login policy.
 
 ### Validation
 

--- a/docs/migration-admin-to-roles.md
+++ b/docs/migration-admin-to-roles.md
@@ -167,6 +167,55 @@ role.id == "space-admin"
 
 ---
 
+## One space per stack (1-space-per-stack refactor)
+
+This module version adds support for creating a dedicated Spacelift space for every managed stack,
+giving each stack independent access control and self-management capability.
+
+### New root variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `stacks_dedicated_space_enabled` | `bool` | `false` | Create a dedicated `spacelift_space` for every managed stack. Set to `true` in `catalog/spacelift/defaults.yaml` to enable globally. Overridable per-stack via `settings.spacelift.dedicated_space_enabled`. |
+| `stacks_self_admin_enabled` | `bool` | `false` | Attach `space-admin` role to each managed stack in its own dedicated space. Requires `stacks_dedicated_space_enabled = true`. Overridable per-stack via `settings.spacelift.administrative`. |
+| `stacks_inherit_entities` | `bool` | `true` | Whether managed stack dedicated spaces inherit worker pools and contexts from their parent space. Overridable per-stack via `settings.spacelift.inherit_entities`. |
+| `write_login_access_github_teams` | `list(string)` | `[]` | GitHub teams granted write access to all dedicated spaces (encoded as `write_access_github_team:<team>` labels). Overridable per-stack via `settings.spacelift.write_login_access_github_teams`. |
+| `admin_login_access_github_teams` | `list(string)` | `[]` | GitHub teams granted admin access to all dedicated spaces (encoded as `admin_access_github_team:<team>` labels). Overridable per-stack via `settings.spacelift.admin_login_access_github_teams`. |
+
+### `space_name` default change
+
+`space_name` for dedicated spaces now defaults to the Spacelift **stack name** (e.g. `guests-ue1-prod`) instead of `component_name` (e.g. `spoton-app`). This ensures uniqueness across stacks. Override per-stack via `settings.spacelift.space_name`.
+
+### Enabling globally in `stacks/catalog/spacelift/defaults.yaml`
+
+```yaml
+vars:
+  stacks_dedicated_space_enabled: true
+  stacks_self_admin_enabled: true
+  stacks_inherit_entities: true
+```
+
+The `write_login_access_github_teams` and `admin_login_access_github_teams` values are inherited from the admin stack's existing `_spacelift-space.yaml` vars — no per-stack YAML changes required.
+
+### Login policy update
+
+The `template-rego-policies/login.github.rego` template now includes label-based `space_write` / `space_admin` rules that match `write_access_github_team:<team>` and `admin_access_github_team:<team>` labels on dedicated spaces. The existing single login policy covers all dedicated spaces with no extra policies needed.
+
+### Validation
+
+Setting `stacks_self_admin_enabled = true` without `stacks_dedicated_space_enabled = true` will fail with:
+
+```
+Error: Resource precondition failed
+administrative = true requires dedicated_space_enabled = true to scope the space-admin role to the stack's own dedicated space.
+```
+
+### No state migration required
+
+Managed stacks have no pre-existing dedicated spaces. Terraform creates them fresh. The `space_id` attribute change on existing stacks is an in-place update (no ForceNew) — run history is preserved.
+
+---
+
 ## Rollback procedure
 
 If something goes wrong after applying:

--- a/main.tf
+++ b/main.tf
@@ -106,9 +106,9 @@ module "stacks" {
   )
 
   enabled                            = each.value.enabled
-  dedicated_space_enabled            = try(each.value.settings.spacelift.dedicated_space_enabled, false)
-  space_name                         = try(each.value.settings.spacelift.space_name, null)
-  inherit_entities                   = try(each.value.settings.spacelift.inherit_entities, false)
+  dedicated_space_enabled            = try(each.value.settings.spacelift.dedicated_space_enabled, var.stacks_dedicated_space_enabled)
+  space_name                         = try(each.value.settings.spacelift.space_name, module.spacelift_stacks_from_atmos_config.spacelift_stacks_extra_args[each.key].stack_name)
+  inherit_entities                   = try(each.value.settings.spacelift.inherit_entities, var.stacks_inherit_entities)
   stack_name                         = module.spacelift_stacks_from_atmos_config.spacelift_stacks_extra_args[each.key].stack_name
   atmos_stack_name                   = each.value.stack
   component_name                     = each.value.component
@@ -139,7 +139,10 @@ module "stacks" {
 
   component_root        = coalesce(try(each.value.settings.spacelift.component_root, null), format("%s/%s", var.components_path, coalesce(each.value.base_component, each.value.component)))
   local_preview_enabled = try(each.value.settings.spacelift.local_preview_enabled, null) != null ? each.value.settings.spacelift.local_preview_enabled : var.local_preview_enabled
-  administrative        = try(each.value.settings.spacelift.administrative, null) != null ? each.value.settings.spacelift.administrative : var.administrative
+  administrative        = try(each.value.settings.spacelift.administrative, var.stacks_self_admin_enabled, var.administrative)
+
+  write_login_access_github_teams = try(each.value.settings.spacelift.write_login_access_github_teams, var.write_login_access_github_teams)
+  admin_login_access_github_teams = try(each.value.settings.spacelift.admin_login_access_github_teams, var.admin_login_access_github_teams)
 
   azure_devops         = try(each.value.settings.spacelift.azure_devops, null)
   bitbucket_cloud      = try(each.value.settings.spacelift.bitbucket_cloud, null)

--- a/modules/spacelift-stack/main.tf
+++ b/modules/spacelift-stack/main.tf
@@ -20,6 +20,13 @@ locals {
 resource "spacelift_stack" "this" {
   count = local.enabled ? 1 : 0
 
+  lifecycle {
+    precondition {
+      condition     = !var.administrative || var.dedicated_space_enabled
+      error_message = "administrative = true requires dedicated_space_enabled = true to scope the space-admin role to the stack's own dedicated space, not the shared admin space."
+    }
+  }
+
   space_id = (
     alltrue([var.administrative, var.dedicated_space_enabled]) ? "root" :
     try(spacelift_space.default[0].id, var.space_id)
@@ -185,7 +192,11 @@ resource "spacelift_space" "default" {
   parent_space_id  = var.parent_space_id
   inherit_entities = var.inherit_entities
   description      = var.description
-  labels           = var.labels
+  labels = concat(
+    var.labels,
+    [for t in var.write_login_access_github_teams : "write_access_github_team:${t}"],
+    [for t in var.admin_login_access_github_teams : "admin_access_github_team:${t}"],
+  )
 }
 
 resource "spacelift_context" "managed_space" {

--- a/modules/spacelift-stack/main.tf
+++ b/modules/spacelift-stack/main.tf
@@ -28,7 +28,7 @@ resource "spacelift_stack" "this" {
   }
 
   space_id = (
-    alltrue([var.administrative, var.dedicated_space_enabled]) ? "root" :
+    alltrue([var.administrative, var.dedicated_space_enabled, coalesce(var.parent_space_id, "root") == "root"]) ? "root" :
     try(spacelift_space.default[0].id, var.space_id)
   )
 

--- a/modules/spacelift-stack/variables.tf
+++ b/modules/spacelift-stack/variables.tf
@@ -354,7 +354,7 @@ variable "dedicated_space_enabled" {
 
 variable "space_name" {
   type        = string
-  description = "Name of the dedicated space to create. Defaults to component_name if not set."
+  description = "Name of the dedicated space to create. Defaults to stack_name if not set."
   default     = null
 }
 
@@ -362,6 +362,18 @@ variable "inherit_entities" {
   type        = bool
   description = "Whether the dedicated space should inherit entities from its parent space"
   default     = false
+}
+
+variable "write_login_access_github_teams" {
+  type        = list(string)
+  description = "GitHub teams granted write access to this stack's dedicated space. Encoded as write_access_github_team:<team> labels on the dedicated space."
+  default     = []
+}
+
+variable "admin_login_access_github_teams" {
+  type        = list(string)
+  description = "GitHub teams granted admin access to this stack's dedicated space. Encoded as admin_access_github_team:<team> labels on the dedicated space."
+  default     = []
 }
 
 variable "parent_space_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -422,3 +422,33 @@ variable "spacelift_stack_dependency_enabled" {
   description = "If enabled, the `spacelift_stack_dependency` Spacelift resource will be used to create dependencies between stacks instead of using the `depends-on` labels. The `depends-on` labels will be removed from the stacks and the trigger policies for dependencies will be detached"
   default     = false
 }
+
+variable "stacks_dedicated_space_enabled" {
+  type        = bool
+  description = "Create a dedicated Spacelift space for every managed stack. Overridable per-stack via settings.spacelift.dedicated_space_enabled."
+  default     = false
+}
+
+variable "stacks_self_admin_enabled" {
+  type        = bool
+  description = "Attach space-admin role to each managed stack in its own dedicated space, enabling self-management of Spacelift resources. Only meaningful when stacks_dedicated_space_enabled = true. Overridable per-stack via settings.spacelift.administrative."
+  default     = false
+}
+
+variable "stacks_inherit_entities" {
+  type        = bool
+  description = "Whether managed stack dedicated spaces inherit entities (worker pools, contexts) from their parent space. Overridable per-stack via settings.spacelift.inherit_entities."
+  default     = true
+}
+
+variable "write_login_access_github_teams" {
+  type        = list(string)
+  description = "GitHub teams granted write access to managed stack dedicated spaces. Encoded as write_access_github_team:<team> labels on each dedicated space. Overridable per-stack via settings.spacelift.write_login_access_github_teams."
+  default     = []
+}
+
+variable "admin_login_access_github_teams" {
+  type        = list(string)
+  description = "GitHub teams granted admin access to managed stack dedicated spaces. Encoded as admin_access_github_team:<team> labels on each dedicated space. Overridable per-stack via settings.spacelift.admin_login_access_github_teams."
+  default     = []
+}


### PR DESCRIPTION
### What
<sub>This section was generated by AI.</sub>

- Add `stacks_dedicated_space_enabled`, `stacks_self_admin_enabled`, `stacks_inherit_entities` root variables (all opt-in, `default = false/true`, backward-compatible)
- Add `write_login_access_github_teams` / `admin_login_access_github_teams` root + `spacelift-stack` module variables; encode as `write_access_github_team:<t>` / `admin_access_github_team:<t>` labels on dedicated spaces
- `space_name` defaults to Spacelift stack name (unique per stack) instead of `component_name`
- `lifecycle.precondition` on `spacelift_stack`: `administrative = true` requires `dedicated_space_enabled = true`
- Fix `space_id → root` placement: only top-level admin stacks (parent_space_id == root) go to root; managed stacks go to their own dedicated space
- `administrative` flag removed from `spacelift_stack` resource; replaced by `spacelift_role_attachment` with `space-admin` slug (Spacelift deprecated the flag June 1 2026)
- Migration guide updated with 1-space-per-stack section

Paired infra PR: SpotOnInc/infrastructure#20968

### Why

_<!-- describe why this change is needed -->_

### Assisted-by
<sub>Specific models used per commit are specified in the commit messages.</sub>

- Assisted-by: Sisyphus:claude-sonnet-4-6 opencode (d3dd092, a63bca2)